### PR TITLE
New way to authentication in 2 steps : register & verifyotp then autologin

### DIFF
--- a/src/publicApi_v8/aesEncryption.ts
+++ b/src/publicApi_v8/aesEncryption.ts
@@ -314,65 +314,6 @@ aesEncryption.post( '/validate-autologin', validateRequestBody,
       })
     }
     })
-// aesEncryption.post('/registerUserWithMobile', async (req, res) => {
-//   try {
-//     if (!req.body.phone) {
-//       res.status(400).json({
-//         msg: EMAIL_OR_MOBILE_ERROR_MSG,
-//         status: 'error',
-//         status_code: 400,
-//       })
-//     }
-//     const { firstName, phone, lastName, password } = req.body
-//     // tslint:disable-next-line: no-any
-//     let profile: any = {}
-//     let isUserExist = {}
-//     // tslint:disable-next-line: no-any
-//     let newUserDetails: any = {}
-//     logInfo('Req body', req.body)
-//     isUserExist = await fetchUserBymobileorEmail(phone, 'phone')
-//     if (!isUserExist) {
-//       logInfo('creating new  user')
-//       profile = {
-//         fname: firstName,
-//         lname: lastName,
-//         mobile: phone,
-//         psw: password,
-//         type: 'phone',
-//       }
-//       newUserDetails = await createuserWithmobileOrEmail(profile).catch(
-//         handleCreateUserError
-//       )
-//       if (newUserDetails) {
-//         const userUUId = newUserDetails.result.userId
-//         const response = await getOTP(userUUId, phone, 'phone')
-//         // tslint:disable-next-line: no-console
-//         console.log('response form getOTP : ' + response)
-//         if (response.data.result.response === 'SUCCESS') {
-//           res.status(200).json({
-//             msg: 'user created successfully',
-//             status: 'success',
-//             status_code: 200,
-//             userUUId: newUserDetails.result.userId,
-//           })
-//         }
-//         logInfo('Sending Responses in phone part : ' + newUserDetails)
-//       }
-//     } else {
-//       logInfo('Mobile no. already exists.')
-//       res.status(400).json({
-//         msg: 'Mobile no.  already exists.',
-//         status: 'error',
-//         status_code: 400,
-//       })
-//       return
-//     }
-//   } catch (error) {
-//     res.status(500).send({
-//       error: GENERAL_ERROR_MSG,
-//     })
-//   }
-// })
 
 // tslint:disable-next-line: no-any
 const handleCreateUserError = (error: any) => {

--- a/src/publicApi_v8/aesEncryption.ts
+++ b/src/publicApi_v8/aesEncryption.ts
@@ -1,0 +1,481 @@
+import axios from 'axios'
+import { Router } from 'express'
+import { Request, Response } from 'express'
+import jwt_decode from 'jwt-decode'
+import _ from 'lodash'
+import qs from 'querystring'
+import { axiosRequestConfig } from '../configs/request.config'
+import { CONSTANTS } from '../utils/env'
+import { logError, logInfo } from '../utils/logger'
+import { getOTP, validateOTP } from './otp'
+import { getCurrentUserRoles } from './rolePermission'
+const API_END_POINTS = {
+  createUserWithMobileNo: `${CONSTANTS.KONG_API_BASE}/user/v3/create`,
+  fetchUserByEmail: `${CONSTANTS.KONG_API_BASE}/user/v1/exists/email/`,
+  fetchUserByMobileNo: `${CONSTANTS.KONG_API_BASE}/user/v1/exists/phone/`,
+  generateOtp: `${CONSTANTS.SUNBIRD_PROXY_API_BASE}/otp/v1/generate`,
+  grantAccessToken: `${CONSTANTS.HTTPS_HOST}/auth/realms/sunbird/protocol/openid-connect/token`,
+  keycloak_redirect_url: `${CONSTANTS.KEYCLOAK_REDIRECT_URL}`,
+  searchSb: `${CONSTANTS.LEARNER_SERVICE_API_BASE}/private/user/v1/search`,
+  userRoles: `${CONSTANTS.SUNBIRD_PROXY_API_BASE}/user/private/v1/assign/role`,
+  verifyOtp: `${CONSTANTS.SUNBIRD_PROXY_API_BASE}/otp/v1/verify`,
+}
+
+const GENERAL_ERROR_MSG = 'Failed due to unknown reason'
+const VALIDATION_FAIL = 'Please provide correct otp and try again.'
+const OTP_GENERATE_FAIL = 'Please provide correct otp and try again.'
+const CREATION_FAIL = 'Sorry ! User not created. Please try again in sometime.'
+const OTP_MISSING = 'Otp cannnot be blank'
+const EMAIL_OR_MOBILE_ERROR_MSG = 'Mobile no. or Email Id can not be empty'
+const NOT_USER_FOUND = 'User not found.'
+const AUTH_FAIL = 'Authentication failed ! Please check credentials and try again.'
+const AUTHENTICATED = 'Success ! User is sucessfully authenticated.'
+const PASSWORD_REQD = 'Password is required to validate'
+
+export const aesEncryption = Router()
+aesEncryption.post('/register', async (req, res) => {
+  try {
+    logInfo('Entered into Register >>>>>', req.body.email)
+    if (!req.body.email) {
+      res.status(400).json({
+        msg: 'Email id. can not be empty',
+        status: 'error',
+        status_code: 400,
+      })
+    }
+    const { firstName, email, lastName, password } = req.body
+    // tslint:disable-next-line: no-any
+    let profile: any = {}
+    let isUserExist = {}
+    // tslint:disable-next-line: no-any
+    let newUserDetails: any = {}
+    logInfo('Req body', req.body)
+    isUserExist = await fetchUserBymobileorEmail(email, 'email')
+    if (!isUserExist) {
+      logInfo('creating new  user')
+      // tslint:disable-next-line: no-any
+      profile = {
+        emailId: email,
+        fname: firstName,
+        lname: lastName,
+        psw: password,
+        type: 'email',
+      }
+      logInfo('Checking profile data ' + profile)
+      newUserDetails = await createuserWithmobileOrEmail(profile).catch(
+        handleCreateUserError
+      )
+      if (newUserDetails) {
+        const userUUId = newUserDetails.result.userId
+        const response = await getOTP(userUUId, email, 'email')
+        // tslint:disable-next-line: no-console
+        console.log('response form getOTP : ' + response)
+        if (response.data.result.response === 'SUCCESS') {
+          res.status(200).json({
+            msg: 'user created successfully',
+            status: 'success',
+            status_code: 200,
+            userUUId: newUserDetails.result.userId,
+          })
+        }
+      } else {
+        logInfo('Email already exists.')
+        res.status(400).json({
+          msg: 'Email id  already exists.',
+          status: 'error',
+          status_code: 400,
+        })
+        return
+      }
+    } else {
+      logInfo('Email already exists.')
+      res.status(400).json({
+        msg: 'Email id  already exists.',
+        status: 'error',
+        status_code: 400,
+      })
+      return
+    }
+  } catch (error) {
+    logInfo('Error in user creation >>>>>>' + error)
+    res.status(500).send({
+      message: CREATION_FAIL,
+      status: 'failed',
+    })
+  }
+})
+
+// generate otp for  register's user
+aesEncryption.post('/generateOtp', async (req, res) => {
+  try {
+    if (req.body.mobileNumber || req.body.email) {
+      logInfo('Entered into /generateOtp ')
+      const mobileNumber = req.body.mobileNumber
+      const email = req.body.email
+      // tslint:disable-next-line: no-any
+      // let userSearch: any = {}
+      const userSearch = await axios({
+        ...axiosRequestConfig,
+        data: {
+          request: {
+            filters: mobileNumber
+              ? { phone: mobileNumber.toLowerCase() }
+              : { email: email.toLowerCase() },
+            query: '',
+          },
+        },
+        method: 'POST',
+        url: API_END_POINTS.searchSb,
+      })
+      logInfo('userSearch response' + userSearch)
+      if (userSearch.data.result.response) {
+        if (userSearch.data.result.response.count > 0) {
+          const userUUId = _.get(
+            _.find(userSearch.data.result.response.content, 'userId'),
+            'userId'
+          )
+          const response = await getOTP(
+            userUUId,
+            email ? email : mobileNumber,
+            email ? 'email' : 'phone'
+          )
+          // tslint:disable-next-line: no-console
+          console.log('2 response form getOTP : ' + response)
+          if (response.data.result.response === 'SUCCESS') {
+            res
+              .status(200)
+              .send({ message: 'Success ! Please verify the OTP .' })
+          }
+        }
+      } else {
+        res.status(400).send({ message: NOT_USER_FOUND })
+      }
+    } else if (!req.body.mobileNumber || !req.body.email) {
+      res.status(400).json({
+        msg: EMAIL_OR_MOBILE_ERROR_MSG,
+        status: 'error',
+        status_code: 400,
+      })
+    }
+  } catch (error) {
+    logInfo('Generate otp  error >> ' + error)
+    res.status(500).send({
+      message: OTP_GENERATE_FAIL,
+      status: 'failed',
+    })
+  }
+})
+// tslint:disable-next-line: no-any
+const validateRequestBody = (req: Request, res: Response, next: any) => {
+  if (!req.body.otp) {
+    res.status(400).json({
+      msg: 'OTP. can not be empty',
+      status: 'error',
+      status_code: 400,
+    })
+  }
+  if (!req.body.password) {
+    res.status(400).json({
+      msg: 'Password. can not be empty',
+      status: 'error',
+      status_code: 400,
+    })
+  }
+  next()
+}
+
+// validate  otp for  register's the user
+aesEncryption.post( '/validate-autologin', validateRequestBody,
+  async (req:any, res, next) => {
+    try {
+      if(!req.body.password)
+      {
+        res.status(400).json({
+            msg: PASSWORD_REQD,
+            status: 'success',
+        })
+      }
+      if (req.body.mobileNumber || req.body.email) {
+        logInfo('Entered into /validateOtp ', req.body)
+        const mobileNumber = req.body.mobileNumber
+        const email = req.body.email
+        const validOtp = req.body.otp
+        const userUUId = req.body.userUUId || req.body.userUUID
+        if (!validOtp) {
+          res.status(400).send({ message: OTP_MISSING, status: 'error' })
+          return
+        }
+        const verifyOtpResponse = await validateOTP(
+          userUUId,
+          mobileNumber ? mobileNumber : email,
+          email ? 'email' : 'phone',
+          validOtp
+        )
+        if (verifyOtpResponse.data.result.response === 'SUCCESS') {
+
+          logInfo('opt verify : ')
+          setTimeout(() => {
+            updateRoles(userUUId)
+        }, 5000)
+
+        logInfo('Success validate otp now keycloak_redirect_url URI:>>>>', API_END_POINTS.keycloak_redirect_url)
+        logInfo('Sending Responses in phone part : ' + verifyOtpResponse)
+        logInfo('mobileNumber ? mobileNumber : email part : ' + mobileNumber ? mobileNumber : email)
+        logInfo('req.body.password : ' + verifyOtpResponse)
+        logInfo('Sending Responses in phone part : ' + verifyOtpResponse)
+
+        req.session.user = null
+        // tslint:disable-next-line: no-any
+        req.session.save(async (err: any) => {
+            if (err) next(err)
+            req.session.regenerate(async () => {
+            // will have a new session here
+            try {
+                logInfo('Entered into /login/authv2 endpoint >>> ')
+
+                try {
+                    logInfo('Redirect URI:>>>>', API_END_POINTS.keycloak_redirect_url)
+
+                    const transformedData = qs.stringify({
+                        client_id: 'portal',
+                        username : mobileNumber ? mobileNumber : email,
+                        grant_type: 'password',
+                        password: req.body.password,
+                        })
+                        logInfo('Entered into authorization part.' + transformedData)
+                        const authTokenResponse = await axios({
+                        ...axiosRequestConfig,
+                        data: transformedData,
+                        headers: {
+                            'Content-Type': 'application/x-www-form-urlencoded',
+                        },
+                        method: 'POST',
+                        url: API_END_POINTS.grantAccessToken,
+                        })
+                        logInfo('Entered into authTokenResponsev2 :' + authTokenResponse)
+                        if (authTokenResponse.data) {
+                            const accessToken = authTokenResponse.data.access_token
+                            // tslint:disable-next-line: no-any
+                            const decodedToken: any = jwt_decode(accessToken)
+                            const decodedTokenArray = decodedToken.sub.split(':')
+                            const userId = decodedTokenArray[decodedTokenArray.length - 1]
+                            req.session.userId = userId
+                            req.kauth = {
+                                grant: {
+                                access_token: { content: decodedToken, token: accessToken },
+                                },
+                            }
+                            req.session.grant = {
+                                access_token: { content: decodedToken, token: accessToken },
+                            }
+                            logInfo('Success ! Entered into usertokenResponse..')
+                            await getCurrentUserRoles(req, accessToken)
+                
+                            res.status(200).json({
+                                msg: AUTHENTICATED,
+                                status: 'success',
+                            })
+                    } else {
+                        res.status(302).json({
+                        msg: AUTH_FAIL,
+                        status: 'failed',
+                        })
+                    }
+                }catch (e) {
+                    logInfo('Error throwing Cookie inside auth route : ' + e)
+                    res.status(400).send({
+                        error: AUTH_FAIL,
+                        status:'failed'
+                    })
+                }
+            } catch (error) {
+                logInfo('error' + error)
+
+                res.status(500).send({
+                error: GENERAL_ERROR_MSG,
+                status:'failed'
+                })
+            }
+            })
+        })
+        
+      } else {
+        res.status(400).json({
+          msg: EMAIL_OR_MOBILE_ERROR_MSG,
+          status: 'error',
+          status_code: 400,
+        })
+        } 
+      } 
+    }catch (error) {
+      res.status(500).send({
+        message: VALIDATION_FAIL,
+        status: 'failed',
+      })
+    }
+    })
+// aesEncryption.post('/registerUserWithMobile', async (req, res) => {
+//   try {
+//     if (!req.body.phone) {
+//       res.status(400).json({
+//         msg: EMAIL_OR_MOBILE_ERROR_MSG,
+//         status: 'error',
+//         status_code: 400,
+//       })
+//     }
+//     const { firstName, phone, lastName, password } = req.body
+//     // tslint:disable-next-line: no-any
+//     let profile: any = {}
+//     let isUserExist = {}
+//     // tslint:disable-next-line: no-any
+//     let newUserDetails: any = {}
+//     logInfo('Req body', req.body)
+//     isUserExist = await fetchUserBymobileorEmail(phone, 'phone')
+//     if (!isUserExist) {
+//       logInfo('creating new  user')
+//       profile = {
+//         fname: firstName,
+//         lname: lastName,
+//         mobile: phone,
+//         psw: password,
+//         type: 'phone',
+//       }
+//       newUserDetails = await createuserWithmobileOrEmail(profile).catch(
+//         handleCreateUserError
+//       )
+//       if (newUserDetails) {
+//         const userUUId = newUserDetails.result.userId
+//         const response = await getOTP(userUUId, phone, 'phone')
+//         // tslint:disable-next-line: no-console
+//         console.log('response form getOTP : ' + response)
+//         if (response.data.result.response === 'SUCCESS') {
+//           res.status(200).json({
+//             msg: 'user created successfully',
+//             status: 'success',
+//             status_code: 200,
+//             userUUId: newUserDetails.result.userId,
+//           })
+//         }
+//         logInfo('Sending Responses in phone part : ' + newUserDetails)
+//       }
+//     } else {
+//       logInfo('Mobile no. already exists.')
+//       res.status(400).json({
+//         msg: 'Mobile no.  already exists.',
+//         status: 'error',
+//         status_code: 400,
+//       })
+//       return
+//     }
+//   } catch (error) {
+//     res.status(500).send({
+//       error: GENERAL_ERROR_MSG,
+//     })
+//   }
+// })
+
+// tslint:disable-next-line: no-any
+const handleCreateUserError = (error: any) => {
+  logInfo('Error ocurred while creating user' + error)
+  if (_.get(error, 'error.params')) {
+    throw error.error.params
+  } else if (error instanceof Error) {
+    throw error.message
+  } else {
+    throw new Error('unhandled exception while getting userDetails')
+  }
+}
+// tslint:disable-next-line: no-any
+
+const fetchUserBymobileorEmail = async (
+  searchValue: string,
+  searchType: string
+) => {
+  logInfo(
+    'Checking Fetch Mobile no : ',
+    API_END_POINTS.fetchUserByMobileNo + searchValue
+  )
+  try {
+    const response = await axios({
+      ...axiosRequestConfig,
+      headers: {
+        Authorization: CONSTANTS.SB_API_KEY,
+      },
+      method: 'GET',
+      url:
+        searchType === 'email'
+          ? API_END_POINTS.fetchUserByEmail + searchValue
+          : API_END_POINTS.fetchUserByMobileNo + searchValue,
+    })
+    logInfo('Response Data in JSON :', JSON.stringify(response.data))
+    logInfo('Response Data in Success :', response.data.responseCode)
+    if (response.data.responseCode === 'OK') {
+      logInfo(
+        'Response result.exists :',
+        _.get(response, 'data.result.exists')
+      )
+      return _.get(response, 'data.result.exists')
+    }
+  } catch (err) {
+    logError('fetchUserByMobile  failed')
+  }
+}
+// tslint:disable-next-line: no-any
+const updateRoles = async (userUUId: string) => {
+  try {
+    return await axios({
+      ...axiosRequestConfig,
+      data: {
+        request: {
+          organisationId: '0132317968766894088',
+          roles: ['PUBLIC'],
+          userId: userUUId,
+        },
+      },
+      headers: { Authorization: CONSTANTS.SB_API_KEY },
+      method: 'POST',
+      url: API_END_POINTS.userRoles,
+    })
+  } catch (err) {
+    logError('update roles failed ' + err)
+    return 'false'
+  }
+}
+// tslint:disable-next-line: no-any
+const createuserWithmobileOrEmail = async (accountDetails: any) => {
+  if (!accountDetails.fname || accountDetails.fname === '') {
+    throw new Error('USER_NAME_NOT_PRESENT')
+  }
+
+  try {
+    const response = await axios({
+      ...axiosRequestConfig,
+      data: {
+        request: {
+          firstName: accountDetails.fname,
+          lastName: accountDetails.lname,
+          password: accountDetails.psw,
+          [accountDetails.type]: accountDetails.mobile
+            ? accountDetails.mobile
+            : accountDetails.emailId,
+        },
+      },
+      headers: {
+        Authorization: CONSTANTS.SB_API_KEY,
+      },
+      method: 'POST',
+      url: API_END_POINTS.createUserWithMobileNo,
+    })
+    if (response.data.responseCode === 'OK') {
+      logInfo('Log of createuser if OK :')
+      return response.data
+    } else {
+      throw new Error(
+        _.get(response.data, 'params.errmsg') ||
+          _.get(response.data, 'params.err')
+      )
+    }
+  } catch (err) {
+    logError('createuserwithmobile failed')
+  }
+}

--- a/src/publicApi_v8/publicApiV8.ts
+++ b/src/publicApi_v8/publicApiV8.ts
@@ -17,7 +17,6 @@ import { publicTnc } from './tnc'
 export const publicApiV8 = express.Router()
 
 publicApiV8.get('/', (_req, res) => {
-  console.log("jdsfdsflkdsnvksdvbks fbk sk bjsk b")
   res.json({
     status: `Public Api is working fine https base: ${CONSTANTS.HTTPS_HOST}`,
   })

--- a/src/publicApi_v8/publicApiV8.ts
+++ b/src/publicApi_v8/publicApiV8.ts
@@ -1,6 +1,7 @@
 import express from 'express'
 import { CONSTANTS } from '../utils/env'
 import { proxyCreatorRoute } from '../utils/proxyCreator'
+import { aesEncryption } from './aesEncryption'
 import { validateCertificate } from './certificateValidate'
 import { publicCompetencyUser } from './competencyUser'
 import { customSignUp } from './customSignup'
@@ -15,6 +16,7 @@ import { publicTnc } from './tnc'
 export const publicApiV8 = express.Router()
 
 publicApiV8.get('/', (_req, res) => {
+  console.log("jdsfdsflkdsnvksdvbks fbk sk bjsk b")
   res.json({
     status: `Public Api is working fine https base: ${CONSTANTS.HTTPS_HOST}`,
   })
@@ -30,6 +32,7 @@ publicApiV8.use(
 publicApiV8.use('/competency', publicCompetencyUser)
 publicApiV8.use('/tnc', publicTnc)
 publicApiV8.use('/signup', signup)
+publicApiV8.use('/autologinSignup', aesEncryption)
 publicApiV8.use('/homePage', homePage)
 publicApiV8.use('/register/', customSignUp)
 publicApiV8.use('/emailMobile/', emailOrMobileLogin)


### PR DESCRIPTION
The api works with 2 different endpoints : 
1. To register into the portal and get user uuid.
  **ENDPOINT :** /public/v8/autologinSignup/register
2. To validate Otp and auto login in portal. ( after otp validated, we are regenerating session and cookies for autologin )
  **ENDPOINT :** /public/v8/autologinSignup/validate-autologin
 