### PR TITLE
Quiz fix: apply falseCreator only to graded assessments (v5.2.7)

### DIFF
--- a/RELEASE_NOTES/5.2.7.md
+++ b/RELEASE_NOTES/5.2.7.md
@@ -1,0 +1,48 @@
+# Release Notes — v5.2.7
+
+| | |
+|---|---|
+| **Build branch** | `production` |
+| **Tag** | `v5.2.7` _(to be created)_ |
+| **Baseline** | `v5.2.6` |
+| **Commits** | 2 (1 fix + release notes) — PR from `quiz-jumbler-falsecreator-fix` |
+| **Author** | Likhith Thammegowda |
+| **Date** | 2026-07-29 |
+
+## Summary
+
+This release fixes practice quizzes that had stopped working in the player. When a quiz was loaded through the proxy, the correct-answer flags were being blanked out before the data reached the app, which broke the app's answer-checking. Those flags are now blanked only for **graded assessments** (which are scored on the server), so **practice quizzes keep the information they need and work again**.
+
+## ✨ Features
+
+_None — patch release._
+
+## 🐛 Fixes
+
+- **Quiz** — `jumbler` now applies `falseCreator` (which zeroes every option's `isCorrect`) **only when `isAssessment` is true**. Practice quizzes are scored client-side (`quiz.service.checkAnswer` reads `isCorrect`); previously every quiz had its flags stripped, so `filter(options,'isCorrect')[0]` became `undefined` and the player threw. Quizzes now retain their real `isCorrect` flags; graded assessments still hide them (`2467ec2`).
+
+## 🏗️ Build / CI / Infra
+
+_None._
+
+## 📚 Docs / Chore
+
+- Added a unit test guarding the `falseCreator` scope so quizzes are never stripped unconditionally again (`2467ec2`).
+
+## ⚠️ Deploy notes & risk
+
+- **Behavioural change by content type:** graded assessments (`isAssessment: true`) continue to have answers hidden (server-side scoring, unchanged). Practice quizzes now expose `isCorrect` in the payload again — this is required for the player's client-side scoring and matches the pre-`jumbler` behaviour.
+- **Relies on `isAssessment` in the quiz JSON:** content without an `isAssessment: true` flag is treated as a quiz and keeps its `isCorrect` flags. Confirm graded assessments actually carry `isAssessment: true` so their answers stay hidden.
+- No config, schema, or dependency changes.
+
+## ✅ Pre-deploy checklist
+
+- [ ] Lint + build pass on `production` at the release commit.
+- [ ] A practice quiz loads, checks answers, and shows results correctly in the player.
+- [ ] A graded assessment still hides answers (options come through with `isCorrect: false`).
+- [ ] Rollback reference confirmed: previous release tag `v5.2.6`.
+
+## Release & rollback
+
+- **Deploy source:** `production` branch at the merge commit (to be tagged `v5.2.7`).
+- **Rollback:** redeploy the previous release — `git checkout v5.2.6` (or re-run the deploy pipeline against `v5.2.6`).

--- a/src/utils/jumbler.ts
+++ b/src/utils/jumbler.ts
@@ -13,10 +13,17 @@ export async function jumbler(path: string) {
     const randomCount =
       response.data.randomCount || response.data.questions.length
     logInfo('Success IN Getting Assessment JSON >>>>>>>>>>>' + response)
-    const questionArray = _.sampleSize(
+    const sampledQuestions = _.sampleSize(
       response.data.questions,
       randomCount
-    ).map(falseCreator)
+    )
+    // Practice quizzes are scored on the client, so they need the real `isCorrect`
+    // flags. Only graded assessments hide the answers via falseCreator (server-side
+    // scoring). Applying falseCreator to a quiz strips every isCorrect, which breaks
+    // the client-side checkAnswer (filter(options,'isCorrect')[0] becomes undefined).
+    const questionArray = response?.data?.isAssessment
+      ? sampledQuestions.map(falseCreator)
+      : sampledQuestions
     const questionObject = {
       isAssessment: response?.data?.isAssessment,
       passPercentage: response?.data?.passPercentage,

--- a/test/jumblerQuizFix.test.js
+++ b/test/jumblerQuizFix.test.js
@@ -1,0 +1,36 @@
+const assert = require("assert");
+const fs = require("fs");
+const path = require("path");
+
+/**
+ * jumbler serves both practice quizzes and graded assessments.
+ * `falseCreator` zeroes every option's isCorrect so the correct answer can't be
+ * read on the client. That is right for GRADED ASSESSMENTS (scored server-side),
+ * but a QUIZ is scored client-side (quiz.service.checkAnswer reads isCorrect), so
+ * stripping the flags breaks it. Guard: apply falseCreator ONLY when isAssessment.
+ */
+describe("jumbler falseCreator scope", function () {
+  const src = fs.readFileSync(
+    path.join(__dirname, "..", "src", "utils", "jumbler.ts"),
+    "utf8"
+  );
+
+  it("applies falseCreator only for graded assessments (isAssessment)", function () {
+    assert.ok(
+      /isAssessment[\s\S]{0,80}\.map\(falseCreator\)/.test(src),
+      "falseCreator must be gated behind an isAssessment check"
+    );
+  });
+
+  it("does NOT strip isCorrect unconditionally", function () {
+    // the old code did `_.sampleSize(...).map(falseCreator)` with no condition
+    assert.ok(
+      !/sampleSize\([\s\S]*?\)\s*\.map\(falseCreator\)/.test(src),
+      "sampled questions must not be piped straight through falseCreator without the isAssessment guard"
+    );
+  });
+
+  it("still defines falseCreator (kept for the assessment path)", function () {
+    assert.ok(/const falseCreator\s*=/.test(src), "falseCreator must remain for graded assessments");
+  });
+});


### PR DESCRIPTION
Fixes practice quizzes broken after routing through jumbler. falseCreator (which zeroes every option isCorrect) now runs only for graded assessments (isAssessment=true); quizzes keep the isCorrect flags the player needs for client-side scoring. Includes a unit test and RELEASE_NOTES/5.2.7.md.