### PR TITLE
jumbler: always report isAssessment=true (v5.2.8)

### DIFF
--- a/RELEASE_NOTES/5.2.8.md
+++ b/RELEASE_NOTES/5.2.8.md
@@ -1,0 +1,47 @@
+# Release Notes — v5.2.8
+
+| | |
+|---|---|
+| **Build branch** | `production` |
+| **Tag** | `v5.2.8` _(to be created)_ |
+| **Baseline** | `v5.2.7` |
+| **Commits** | 2 (1 fix + release notes) — PR from `jumbler-isassessment-flag` |
+| **Author** | Likhith Thammegowda |
+| **Date** | 2026-07-29 |
+
+## Summary
+
+This release makes the quiz/assessment player treat all content through the graded-assessment path. The proxy's `jumbler` response now always reports `isAssessment: true`, so every quiz and assessment is handled consistently by the player.
+
+## ✨ Features
+
+_None — patch release._
+
+## 🐛 Fixes
+
+- **Assessment player** — `jumbler` now returns `isAssessment: true` for all content (previously it forwarded the source content's own flag). The player therefore routes every quiz/assessment through the graded path (`e5c90e4`).
+
+## 🏗️ Build / CI / Infra
+
+_None._
+
+## 📚 Docs / Chore
+
+_None._
+
+## ⚠️ Deploy notes & risk
+
+- **Behavioural change:** all content served through `jumbler` is now flagged `isAssessment: true` to the player, regardless of the content's own `isAssessment` value. Confirm the player behaves as expected for content that was previously treated as a non-graded quiz.
+- **Answer-hiding is unchanged:** `falseCreator` (which zeroes `isCorrect`) still runs only for content whose *source* `isAssessment` is true — so quizzes still keep their real `isCorrect` flags in the payload while being reported as `isAssessment: true`.
+- No config, schema, or dependency changes.
+
+## ✅ Pre-deploy checklist
+
+- [ ] Lint + build pass on `production` at the release commit.
+- [ ] Quiz and assessment both load and submit correctly in the player with the always-`isAssessment` flag.
+- [ ] Rollback reference confirmed: previous release tag `v5.2.7`.
+
+## Release & rollback
+
+- **Deploy source:** `production` branch at the merge commit (to be tagged `v5.2.8`).
+- **Rollback:** redeploy the previous release — `git checkout v5.2.7` (or re-run the deploy pipeline against `v5.2.7`).

--- a/src/utils/jumbler.ts
+++ b/src/utils/jumbler.ts
@@ -25,7 +25,7 @@ export async function jumbler(path: string) {
       ? sampledQuestions.map(falseCreator)
       : sampledQuestions
     const questionObject = {
-      isAssessment: response?.data?.isAssessment,
+      isAssessment: true,
       passPercentage: response?.data?.passPercentage,
       questions: questionArray,
       randomCount,


### PR DESCRIPTION
jumbler now returns isAssessment: true for all content so the player treats every quiz/assessment through the graded path. falseCreator answer-hiding stays gated on the source isAssessment flag. Includes RELEASE_NOTES/5.2.8.md.