### PR TITLE
Issue #000 feat: Serve MNC CNE attendance report from private S3 bucket

### DIFF
--- a/src/protectedApi_v8/mncAttendanceReport.ts
+++ b/src/protectedApi_v8/mncAttendanceReport.ts
@@ -1,0 +1,164 @@
+import AWS from 'aws-sdk'
+import { Request, Response, Router } from 'express'
+import { CONSTANTS } from '../utils/env'
+import { logError, logInfo } from '../utils/logger'
+
+/**
+ * Serves the MNC CNE Attendance Sync report — a single self-contained HTML object held in a
+ * PRIVATE S3 bucket and overwritten daily by the client at a fixed key.
+ *
+ * Why it is proxied rather than handed out as a presigned URL:
+ *  - The report contains a named attendance roster, so access must be gated server side.
+ *    A presigned URL is a bearer credential — shareable, and it leaks into browser history.
+ *  - A stable URL is what makes ETag/304 revalidation work, so the multi-megabyte body only
+ *    transfers on days the content actually changed instead of on every view.
+ */
+
+// Credentials are intentionally read straight from config with no fallback. When they are
+// undefined the AWS SDK falls back to its default credential chain (instance / IRSA role),
+// which is the preferred posture in the cluster.
+const s3 = new AWS.S3({
+    accessKeyId: CONSTANTS.MNC_REPORT_S3_ACCESS_KEY_ID,
+    region: CONSTANTS.MNC_REPORT_S3_REGION,
+    secretAccessKey: CONSTANTS.MNC_REPORT_S3_SECRET_ACCESS_KEY,
+})
+
+const MNC_REPORT_BUCKET = CONSTANTS.MNC_REPORT_S3_BUCKET_NAME
+const MNC_REPORT_KEY = CONSTANTS.MNC_REPORT_S3_KEY
+const REQUIRED_ROLE = 'MNC_REPORT_VIEWER'
+
+export const mncAttendanceReportApi = Router()
+
+/**
+ * The whitelist ROLE_CHECK in apiWhiteList.ts only runs when PORTAL_API_WHITELIST_CHECK is
+ * 'true', and it defaults to 'false'. So the role is re-checked here — access control must
+ * not depend on a feature flag being switched on.
+ */
+// tslint:disable-next-line: no-any
+const hasReportRole = (req: any): boolean => {
+    const roles = req && req.session && req.session.userRoles
+    return Array.isArray(roles) && roles.indexOf(REQUIRED_ROLE) !== -1
+}
+
+const respondForbidden = (res: Response) => {
+    res.status(403).json({
+        id: 'api.error',
+        ver: '1.0',
+        // tslint:disable-next-line: object-literal-sort-keys
+        ts: new Date().toISOString(),
+        params: {
+            status: 'failed',
+            // tslint:disable-next-line: object-literal-sort-keys
+            err: 'FORBIDDEN_ERROR',
+            errmsg: 'Forbidden: you do not have access to this report',
+        },
+        responseCode: 'FORBIDDEN',
+        result: {},
+    })
+}
+
+/** S3 quotes its ETags, and a proxy may weaken them to W/"...". Compare on the bare value. */
+// tslint:disable-next-line: no-any
+const normaliseEtag = (value: any): string => {
+    const raw = Array.isArray(value) ? value[0] : value
+    return String(raw || '').trim().replace(/^W\//, '').replace(/"/g, '')
+}
+
+const isMisconfigured = (res: Response): boolean => {
+    if (!MNC_REPORT_BUCKET || !MNC_REPORT_KEY) {
+        logError('MNC report: MNC_REPORT_S3_BUCKET_NAME / MNC_REPORT_S3_KEY not configured')
+        res.status(500).json({ error: 'Report storage is not configured' })
+        return true
+    }
+    return false
+}
+
+// tslint:disable-next-line: no-any
+const isNotFound = (err: any): boolean =>
+    Boolean(err) && (err.statusCode === 404 || err.code === 'NotFound' || err.code === 'NoSuchKey')
+
+/**
+ * Cheap HeadObject-backed probe. The portal calls this before pointing an iframe at the
+ * content route, because an iframe cannot surface an HTTP status — it would render the
+ * error body as though it were the report.
+ */
+mncAttendanceReportApi.get('/mnc-attendance/meta', async (req: Request, res: Response) => {
+    if (!hasReportRole(req)) {
+        return respondForbidden(res)
+    }
+    if (isMisconfigured(res)) {
+        return
+    }
+    try {
+        const head = await s3.headObject({ Bucket: MNC_REPORT_BUCKET, Key: MNC_REPORT_KEY }).promise()
+        return res.status(200).json({
+            etag: normaliseEtag(head.ETag),
+            lastModified: head.LastModified ? head.LastModified.toISOString() : null,
+            sizeBytes: head.ContentLength || 0,
+        })
+    } catch (err) {
+        if (isNotFound(err)) {
+            logError('MNC report: object missing at ' + MNC_REPORT_KEY)
+            return res.status(404).json({ error: 'Report has not been uploaded yet' })
+        }
+        logError('MNC report: headObject failed ' + JSON.stringify(err))
+        return res.status(500).json({ error: 'Could not read report metadata' })
+    }
+})
+
+mncAttendanceReportApi.get('/mnc-attendance', async (req: Request, res: Response) => {
+    if (!hasReportRole(req)) {
+        return respondForbidden(res)
+    }
+    if (isMisconfigured(res)) {
+        return
+    }
+    try {
+        const head = await s3.headObject({ Bucket: MNC_REPORT_BUCKET, Key: MNC_REPORT_KEY }).promise()
+        const etag = normaliseEtag(head.ETag)
+
+        // private: never cached by a shared proxy. no-cache: keep the bytes but always
+        // revalidate — exactly right for a fixed URL whose content changes daily.
+        res.setHeader('Cache-Control', 'private, no-cache')
+        res.setHeader('X-Content-Type-Options', 'nosniff')
+        if (etag) {
+            res.setHeader('ETag', '"' + etag + '"')
+        }
+
+        // The whole caching design: on an unchanged object this returns no body at all.
+        const ifNoneMatch = normaliseEtag(req.headers['if-none-match'])
+        if (etag && ifNoneMatch && ifNoneMatch === etag) {
+            logInfo('MNC report: 304 for unchanged object')
+            return res.status(304).end()
+        }
+
+        res.setHeader('Content-Type', 'text/html; charset=utf-8')
+        res.setHeader('Content-Disposition', 'inline')
+
+        // The daily upload is outside our control, so handle either style: if the object was
+        // stored already gzipped, pass it through and declare it (which also makes the global
+        // compression middleware skip it); otherwise let that middleware compress on the fly.
+        if (head.ContentEncoding === 'gzip') {
+            res.setHeader('Content-Encoding', 'gzip')
+        }
+
+        const stream = s3.getObject({ Bucket: MNC_REPORT_BUCKET, Key: MNC_REPORT_KEY }).createReadStream()
+        // tslint:disable-next-line: no-any
+        stream.on('error', (streamErr: any) => {
+            logError('MNC report: stream failed ' + JSON.stringify(streamErr))
+            if (!res.headersSent) {
+                res.status(500).json({ error: 'Could not read report' })
+            } else {
+                res.end()
+            }
+        })
+        return stream.pipe(res)
+    } catch (err) {
+        if (isNotFound(err)) {
+            logError('MNC report: object missing at ' + MNC_REPORT_KEY)
+            return res.status(404).json({ error: 'Report has not been uploaded yet' })
+        }
+        logError('MNC report: getObject failed ' + JSON.stringify(err))
+        return res.status(500).json({ error: 'Could not read report' })
+    }
+})

--- a/src/protectedApi_v8/protectedApiV8.ts
+++ b/src/protectedApi_v8/protectedApiV8.ts
@@ -30,6 +30,7 @@ import { knowledgeHubApi } from './khub'
 import { leaderBoardApi } from './leaderboard'
 import { learnerPathApi } from './learnerPath'
 import { learnerPathApiV2 } from './learnerPathV2'
+import { mncAttendanceReportApi } from './mncAttendanceReport'
 import { navigatorApi } from './navigator'
 import { networkConnectionApi } from './network'
 import { networkHubApi } from './network-hub'
@@ -116,3 +117,4 @@ protectedApiV8.use('/profileupdatev2', profileupdatev2)
 protectedApiV8.use('/playlist', playlistApi)
 protectedApiV8.use('/learnerPath', learnerPathApi)
 protectedApiV8.use('/learnerPathV2', learnerPathApiV2)
+protectedApiV8.use('/report', mncAttendanceReportApi)

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -145,6 +145,13 @@ export const CONSTANTS = {
   MATERNITY_FOUNDATION_ACCESS_KEY: env.MATERNITY_FOUNDATION_ACCESS_KEY,
   MNC_JWT_SECRET: env.MNC_JWT_SECRET || '',
   KEYCLOAK_CLIENT_SECRET_MNC: env.KEYCLOAK_CLIENT_SECRET_MNC || '',
+  // MNC CNE attendance report — private bucket, object overwritten daily at a fixed key.
+  // Credentials stay undefined by default so the AWS SDK uses the instance / IRSA role.
+  MNC_REPORT_S3_ACCESS_KEY_ID: env.MNC_REPORT_S3_ACCESS_KEY_ID,
+  MNC_REPORT_S3_BUCKET_NAME: env.MNC_REPORT_S3_BUCKET_NAME || '',
+  MNC_REPORT_S3_KEY: env.MNC_REPORT_S3_KEY || 'reports/mnc-cne-attendance/latest.html',
+  MNC_REPORT_S3_REGION: env.MNC_REPORT_S3_REGION || 'ap-south-1',
+  MNC_REPORT_S3_SECRET_ACCESS_KEY: env.MNC_REPORT_S3_SECRET_ACCESS_KEY,
 
   RC_MAPPER_HOST: env.RC_MAPPER_HOST,
   PID_API_BASE: env.PID_API_BASE || 'http://localhost:3304',

--- a/src/utils/whitelistApis.ts
+++ b/src/utils/whitelistApis.ts
@@ -20,6 +20,7 @@ const ROLE = {
   IFU_MEMBER: 'IFU_MEMBER',
   MDO_ADMIN: 'MDO_ADMIN',
   MDO_LEADER: 'MDO_LEADER',
+  MNC_REPORT_VIEWER: 'MNC_REPORT_VIEWER',
   PUBLIC: 'PUBLIC',
   SPV_ADMIN: 'SPV_ADMIN',
   WAT_MEMBER: 'WAT_MEMBER',
@@ -1104,6 +1105,18 @@ export const API_LIST = {
       // tslint:disable-next-line: object-literal-sort-keys
       ROLE_CHECK: [ROLE.PUBLIC],
     },
+    // Restricted report: gated on MNC_REPORT_VIEWER, not PUBLIC. The route re-checks the
+    // role itself, because this whitelist only runs when PORTAL_API_WHITELIST_CHECK is true.
+    '/protected/v8/report/mnc-attendance': {
+      checksNeeded: [CHECK.ROLE],
+      // tslint:disable-next-line: object-literal-sort-keys
+      ROLE_CHECK: [ROLE.MNC_REPORT_VIEWER],
+    },
+    '/protected/v8/report/mnc-attendance/meta': {
+      checksNeeded: [CHECK.ROLE],
+      // tslint:disable-next-line: object-literal-sort-keys
+      ROLE_CHECK: [ROLE.MNC_REPORT_VIEWER],
+    },
     '/protected/v8/frac/addDataNodeBulk': {
       checksNeeded: [CHECK.ROLE],
       // tslint:disable-next-line: object-literal-sort-keys
@@ -1833,6 +1846,8 @@ export const API_LIST = {
     '/protected/v8/updateProgressv3/update',
     '/protected/v8/learnerPath',
     '/protected/v8/learnerPathV2',
+    '/protected/v8/report/mnc-attendance',
+    '/protected/v8/report/mnc-attendance/meta',
     '/protected/v8/frac/addDataNodeBulk',
     '/protected/v8/roleactivity/:txt',
     '/protected/v8/connections/update/connection',


### PR DESCRIPTION
## What

Adds two protected endpoints that serve the MNC CNE Attendance Sync report — a single self-contained HTML object held in a **private** S3 bucket and overwritten daily by the client at a fixed key.

| Endpoint | Purpose |
|---|---|
| `GET /protected/v8/report/mnc-attendance/meta` | `HeadObject` → `{ lastModified, etag, sizeBytes }` |
| `GET /protected/v8/report/mnc-attendance` | streams the HTML, with `ETag`/`304` revalidation |

Consumed by a new page in the MDO portal (orgportal), on its own branch.

## Why proxy it instead of issuing a presigned URL

- The report contains a **named attendance roster**, so access has to be gated server side. A presigned URL is a bearer credential — shareable, and it leaks into browser history and logs.
- A **stable URL** is what makes `ETag`/`If-None-Match` work. The object is ~9.4 MB; with 304 revalidation it only transfers on days the upload actually changed, instead of on every view. A rotating presigned URL is a new cache key each time and would re-download it every view.

## Notes for review

- **The role is re-checked inside the route.** `PORTAL_API_WHITELIST_CHECK` defaults to `'false'`, so `isAllowed()` — and therefore the whitelist's `ROLE_CHECK` — may not be mounted at all. Access control shouldn't depend on a feature flag, so the handler verifies `MNC_REPORT_VIEWER` against `req.session.userRoles` itself. It is whitelisted as well, in both the `API_LIST` map and the flat array.
- **Route path deliberately contains no `.html`.** `checkIsStaticRoute` in `apiWhiteList.ts` bypasses every check for paths containing `.html`, `/assets/`, `/content/` etc.
- **No double compression.** If the stored object already has `ContentEncoding: gzip` it is passed through and declared, which makes the global `compression()` middleware skip it; otherwise that middleware compresses on the fly.
- **Credentials default to the instance/IRSA role.** `MNC_REPORT_S3_ACCESS_KEY_ID` / `..._SECRET_ACCESS_KEY` are left undefined unless set, so the SDK uses its default chain rather than static keys.
- Missing bucket/key config returns a clear `500 "Report storage is not configured"` rather than an opaque S3 error.

## Config required before this does anything

Set on the `ui-proxy` deployment (ns `sunbird`):

| Key | Required | Default |
|---|---|---|
| `MNC_REPORT_S3_BUCKET_NAME` | yes | — |
| `MNC_REPORT_S3_KEY` | no | `mnc-cne/dashboard.html` if set in env, else the code default |
| `MNC_REPORT_S3_REGION` | no | `ap-south-1` |
| `MNC_REPORT_S3_ACCESS_KEY_ID` / `..._SECRET_ACCESS_KEY` | only without a pod IAM role | unset → IRSA |

Also needs the `MNC_REPORT_VIEWER` role to exist and be assigned.

## Verification

- `tsc --noEmit`: 0 errors project-wide
- `npm run build` (tslint `--fix` → `gulp build`): exit 0
- S3 access confirmed against the real bucket with the deployed credentials — object readable, 9,894,775 bytes, `ContentType: text/html`, no `ContentEncoding` (so it will be gzipped on the fly)

Post-deploy, the thing to watch is a **304 on reload** — that is what keeps this at ~7 MB/day rather than ~7 MB/view.
