### PR TITLE
Issue #000 chore: Add release notes for v5.2.13

### DIFF
--- a/RELEASE_NOTES/5.2.13.md
+++ b/RELEASE_NOTES/5.2.13.md
@@ -1,0 +1,62 @@
+# Release Notes — v5.2.13
+
+| | |
+|---|---|
+| **Build branch** | `release-5.2.13` |
+| **Tag** | `v5.2.13` _(to be created)_ |
+| **Baseline** | `v5.2.12` |
+| **Commits** | 1 (1 feature) |
+| **Author** | Likhith Thammegowda |
+| **Date** | 2026-08-06 |
+
+## Summary
+
+Adds a way for a small, named group of people to view the MNC CNE attendance report inside the MDO portal. The report is a file the client refreshes once a day and is held in a private storage bucket, so it is served through the portal's backend rather than shared as a link — only users granted a specific role can open it. The backend re-sends the file only on days it has actually changed, so repeat views stay fast.
+
+## ✨ Features
+
+- **MNC attendance report** — new `GET /protected/v8/report/mnc-attendance` and `GET /protected/v8/report/mnc-attendance/meta` stream a self-contained HTML report from a private S3 bucket to holders of the `MNC_REPORT_VIEWER` role. `ETag`/`If-None-Match` returns `304` on an unchanged object, so the ~9.4 MB body transfers only when the daily upload actually changes rather than on every view (`2963f49`).
+
+## 🐛 Fixes
+
+_None._
+
+## 🏗️ Build / CI / Infra
+
+_None._
+
+## 📚 Docs / Chore
+
+_None._
+
+## ⚠️ Deploy notes & risk
+
+- **New config required — the feature is inert without it.** Set on the `ui-proxy` deployment (ns `sunbird`):
+
+  | Key | Required | Default |
+  |---|---|---|
+  | `MNC_REPORT_S3_BUCKET_NAME` | **yes** | none — endpoint returns `500 "Report storage is not configured"` |
+  | `MNC_REPORT_S3_KEY` | no | `reports/mnc-cne-attendance/latest.html` |
+  | `MNC_REPORT_S3_REGION` | no | `ap-south-1` |
+  | `MNC_REPORT_S3_ACCESS_KEY_ID` / `..._SECRET_ACCESS_KEY` | only without a pod IAM role | unset → SDK uses the instance / IRSA chain |
+
+  Credentials, if used at all, belong in the **Secret** — not the ConfigMap.
+- **New role required:** `MNC_REPORT_VIEWER` must exist and be assigned, or every request returns `403`.
+- **Access control does not rely on the whitelist.** `PORTAL_API_WHITELIST_CHECK` defaults to `'false'`, so `isAllowed()` — and its `ROLE_CHECK` — may not be mounted. The route verifies the role against `req.session.userRoles` itself. The whitelist entries are present as a second layer, in both the `API_LIST` map and the flat array.
+- **Additive only.** One new router, two new whitelist entries, one new `ROLE` key, five new env keys. No existing route, response shape, or dependency was modified; `aws-sdk` was already present.
+- **No double compression.** An object stored with `ContentEncoding: gzip` is passed through and declared, which makes the global `compression()` middleware skip it; otherwise that middleware compresses on the fly.
+- No schema or database changes.
+
+## ✅ Pre-deploy checklist
+
+- [ ] Lint + build pass on `production` at the release commit.
+- [ ] `MNC_REPORT_S3_BUCKET_NAME` set on the `ui-proxy` deployment; credentials (if any) in the Secret, not the ConfigMap.
+- [ ] `MNC_REPORT_VIEWER` role exists and is assigned to the intended users.
+- [ ] `/protected/v8/report/mnc-attendance/meta` returns `200` for a role holder and `403` for everyone else.
+- [ ] Reloading the report returns **`304`** with near-zero transfer — if it re-downloads, the `ETag` is being rewritten in transit.
+- [ ] Rollback reference confirmed: previous release branch `release-5.2.12` / tag `v5.2.12`.
+
+## Release & rollback
+
+- **Deploy source:** `release-5.2.13`, cut from `production` at the release commit and tagged `v5.2.13`. Jenkins targets the branch, not the tag.
+- **Rollback:** re-run the deploy pipeline against the previous release branch `release-5.2.12`. Rolling back is safe — the change is additive, so nothing else regresses.


### PR DESCRIPTION
Release notes for **v5.2.13**, covering the MNC CNE attendance report endpoints merged in #186.

Notes-only change — `RELEASE_NOTES/5.2.13.md`, no code.

Once merged, the release artifacts get cut from `production`:
- branch `release-5.2.13` (Jenkins deploy source)
- tag `v5.2.13`
- GitHub Release titled `v5.2.13`, body = the notes file

**Two deploy prerequisites called out in the notes**, since the feature is inert without them:
- `MNC_REPORT_S3_BUCKET_NAME` on the `ui-proxy` deployment — otherwise the endpoint returns `500 "Report storage is not configured"`
- the `MNC_REPORT_VIEWER` role must exist and be assigned — otherwise every request is `403`
