### PR TITLE
Issue #000 fix: Read real user roles for the MNC report gate (v5.2.14)

### DIFF
--- a/RELEASE_NOTES/5.2.14.md
+++ b/RELEASE_NOTES/5.2.14.md
@@ -1,0 +1,58 @@
+# Release Notes — v5.2.14
+
+| | |
+|---|---|
+| **Build branch** | `release-5.2.14` |
+| **Tag** | `v5.2.14` _(to be created)_ |
+| **Baseline** | `v5.2.13` |
+| **Commits** | 1 (1 fix) |
+| **Author** | Likhith Thammegowda |
+| **Date** | 2026-08-06 |
+
+## Summary
+
+Fixes the access check on the MNC CNE attendance report endpoints added in v5.2.13. Those endpoints were checking a list of roles that is the same for every signed-in user, so the check could never recognise the report role and the report was unreachable for everyone. It now reads each user's real roles, so the people granted access can open the report and nobody else can.
+
+## ✨ Features
+
+_None — patch release._
+
+## 🐛 Fixes
+
+- **MNC attendance report access check** — the endpoints read `session.userRoles`, which `permissionHelper.ts` and `rolePermission.ts` both assign a hardcoded 16-role array identical for every user. `MNC_REPORT_VIEWER` is absent from it, so the gate could never pass and both endpoints returned `403` regardless of a user's actual roles. Now reads `session.orgs` — populated from the real user profile — and checks `organisations[].roles`, the same source `SCOPE_CHECK` uses in `apiWhiteList.ts` (`f9f12c2`).
+
+## 🏗️ Build / CI / Infra
+
+_None._
+
+## 📚 Docs / Chore
+
+_None._
+
+## ⚠️ Deploy notes & risk
+
+- **Low risk, tightly scoped.** The change touches one function in `mncAttendanceReport.ts`. No shared middleware, no other route, no response shape, no dependency or schema change.
+- **Adding the role to the hardcoded array was rejected deliberately.** That array is applied to every authenticated session, so including `MNC_REPORT_VIEWER` there would have granted the attendance roster — which carries participant names — to anyone able to log in.
+- **Roles must be assigned per-organisation.** The check reads `organisations[].roles`, so `MNC_REPORT_VIEWER` has to be assigned against the user's organisation (via `/user/private/v1/assign/role`), not only set as a top-level role. Note that endpoint **replaces** a user's roles for that org rather than appending — send existing roles plus the new one.
+- **A fresh login is required after assignment.** `session.orgs` is captured when the session is created, so users granted the role while already signed in must log out and back in before the report opens.
+- Unchanged from v5.2.13: `MNC_REPORT_S3_BUCKET_NAME` must be set on the deployment, or the endpoint returns `500 "Report storage is not configured"`.
+
+> Worth flagging separately for the team, out of scope here: because `session.userRoles` is hardcoded for every user, **every `ROLE_CHECK` in `whitelistApis.ts` is currently ineffective** — all users carry all 16 roles. Fixing that properly would start enforcing real roles across every whitelisted route at once, so it needs its own planned change rather than riding along with this one.
+
+## ✅ Pre-deploy checklist
+
+- [ ] Lint + build pass on `production` at the release commit.
+- [ ] `MNC_REPORT_VIEWER` assigned against the user's **organisation**, and the user has re-logged in since.
+- [ ] `/protected/v8/report/mnc-attendance/meta` returns `200` for a role holder.
+- [ ] Returns `403` for a user without the role — including an `MDO_ADMIN` who lacks it, confirming the gate is not satisfied by admin roles.
+- [ ] Reloading the report returns `304` with near-zero transfer.
+- [ ] Rollback reference confirmed: previous release branch `release-5.2.13` / tag `v5.2.13`.
+
+## Release & rollback
+
+- **Deploy source:** `release-5.2.14`, cut from `production` at the release commit and tagged `v5.2.14`. Jenkins targets the branch, not the tag.
+- **Rollback:** re-run the deploy pipeline against `release-5.2.13`. Safe — reverting only restores the previous behaviour, in which the report endpoints returned `403` for everyone.
+
+## Verification performed
+
+Exercised against the live private bucket before release: `200` with the role and `403` without it, `7,458,237` bytes transferred for a `9,918,937`-byte object (gzip on the fly), and `304` with a zero-byte body on revalidation using a multipart ETag.

--- a/src/protectedApi_v8/mncAttendanceReport.ts
+++ b/src/protectedApi_v8/mncAttendanceReport.ts
@@ -33,11 +33,21 @@ export const mncAttendanceReportApi = Router()
  * The whitelist ROLE_CHECK in apiWhiteList.ts only runs when PORTAL_API_WHITELIST_CHECK is
  * 'true', and it defaults to 'false'. So the role is re-checked here — access control must
  * not depend on a feature flag being switched on.
+ *
+ * Deliberately NOT reading session.userRoles: permissionHelper.ts and rolePermission.ts both
+ * assign it a hardcoded 16-role array, identical for every user, so it cannot gate anything.
+ * session.orgs is populated from the real user profile, and organisations[].roles holds the
+ * user's actual per-organisation roles — the same source SCOPE_CHECK uses.
  */
 // tslint:disable-next-line: no-any
 const hasReportRole = (req: any): boolean => {
-    const roles = req && req.session && req.session.userRoles
-    return Array.isArray(roles) && roles.indexOf(REQUIRED_ROLE) !== -1
+    const orgs = req && req.session && req.session.orgs
+    if (!Array.isArray(orgs)) {
+        return false
+    }
+    // tslint:disable-next-line: no-any
+    return orgs.some((org: any) =>
+        Array.isArray(org && org.roles) && org.roles.indexOf(REQUIRED_ROLE) !== -1)
 }
 
 const respondForbidden = (res: Response) => {


### PR DESCRIPTION
Fixes the access check on the report endpoints shipped in v5.2.13, plus `RELEASE_NOTES/5.2.14.md`.

## The bug

The endpoints checked `session.userRoles` — which `permissionHelper.ts` and `rolePermission.ts` both assign a **hardcoded 16-role array, identical for every user**. `MNC_REPORT_VIEWER` isn't in it, so the gate could never pass: both endpoints returned `403` for everyone, regardless of the roles a user actually held.

## Why not just add the role to that array

Because it's applied to every authenticated session, so `MNC_REPORT_VIEWER` there would grant the attendance roster — which contains participant names — to anyone who can log in. That's the opposite of the requirement.

## The fix

Reads `session.orgs`, which *is* populated from the real user profile, and checks `organisations[].roles` — the same source `SCOPE_CHECK` already uses in `apiWhiteList.ts`. One function in `mncAttendanceReport.ts`; no shared middleware, no other route, no response shape changed.

## Verified against the live bucket

- `200` with the role; `403` without it — including for an `MDO_ADMIN` who lacks it, so admin roles don't satisfy the gate
- `7,458,237` bytes transferred for a `9,918,937`-byte object (gzip on the fly)
- `304` with a zero-byte body on revalidation, with a multipart ETag
- `tsc --noEmit` 0 errors; `gulp build` clean

## Two operational notes

- Role must be assigned **per-organisation**, not just top-level — the check reads `organisations[].roles`. `/user/private/v1/assign/role` **replaces** roles for that org, so send existing roles plus the new one.
- `session.orgs` is captured at session creation, so anyone granted the role while already signed in must **re-login** before the report opens.

## Out of scope, worth planning

Because `session.userRoles` is hardcoded for all users, **every `ROLE_CHECK` in `whitelistApis.ts` is currently ineffective** — all users carry all 16 roles. Fixing that properly would begin enforcing real roles across every whitelisted route simultaneously, so it needs its own change rather than riding along here.
